### PR TITLE
fix: context limit, stuck hw_lock, and Anthropic stream termination

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+**Install dependencies:**
+```bash
+uv sync
+```
+
+**Run the server (manual/host):**
+```bash
+uv run server.py \
+  --rkllm_model_path=models/YOUR_MODEL.rkllm \
+  --target_platform=rk3588 \
+  --port=8080
+```
+
+**Run the test client:**
+```bash
+# Chat (streaming)
+uv run client.py --host http://localhost:8080 --prompt "Hello" --stream
+
+# Chat (non-streaming)
+uv run client.py --host http://localhost:8080 --prompt "Hello"
+
+# Embeddings
+uv run client.py --host http://localhost:8080 --prompt "Hello" --embeddings
+```
+
+**Docker:**
+```bash
+# Build
+docker build -t rkllm-server .
+
+# Run via compose (place .rkllm models in ./models/)
+mkdir models
+docker compose up -d
+```
+
+**Health check:**
+```bash
+curl http://localhost:8080/health
+```
+
+## Architecture
+
+This is a single-process FastAPI server that wraps Rockchip's RKLLM runtime (NPU inference) behind OpenAI-compatible and Ollama-compatible REST APIs.
+
+### Key Files
+
+- **`server.py`** — FastAPI app, all HTTP endpoints, request/response models, startup logic (argument parsing, model load, uvicorn)
+- **`rkllm.py`** — Low-level Python `ctypes` bindings to `lib/librkllmrt.so`. Contains the `RKLLM` class (init/run/abort/release), the C callback (`callback_impl`), and generator functions `get_RKLLM_output` (streaming tokens) and `get_RKLLM_embeddings`
+- **`utils.py`** — `apply_chat_template` (ChatML format builder with vision/multimodal support) and `make_llm_response` (OpenAI response envelope)
+- **`lib/librkllmrt.so`** — Rockchip's closed-source NPU runtime (ARM only, RK3588/RK3576)
+
+### Request Flow
+
+1. HTTP request → FastAPI endpoint in `server.py`
+2. Messages formatted via `apply_chat_template()` in `utils.py` (ChatML format)
+3. `get_RKLLM_output()` in `rkllm.py` spawns a thread calling `RKLLM.run()` which calls `rkllm_lib.rkllm_run()`
+4. The C runtime fires `callback_impl` for each token → tokens placed on `output_queue`
+5. Generator yields tokens back to FastAPI → streamed or accumulated per endpoint
+
+### Hardware Concurrency
+
+A global `hw_lock = threading.Lock()` in `server.py` serializes all NPU requests. The NPU can only run one inference at a time. Requests wait up to 30s for the lock; otherwise return HTTP 503.
+
+### API Endpoints
+
+| Endpoint | Protocol |
+|---|---|
+| `POST /v1/chat/completions` | OpenAI |
+| `GET /v1/models` | OpenAI |
+| `POST /v1/embeddings` | OpenAI |
+| `POST /v1/messages` | Anthropic |
+| `POST /api/chat` | Ollama |
+| `GET /api/tags`, `/api/ps`, `/api/version` | Ollama |
+| `GET /hello` | Quick smoke test |
+| `GET /health` | Health check |
+
+### Embeddings
+
+Embeddings use `RKLLM_INFER_GET_LAST_HIDDEN_LAYER` mode — the NPU runs inference, the callback captures the hidden-layer vector (not text tokens), and the mode is switched back to `RKLLM_INFER_GENERATE` afterward.
+
+### Vision / Multimodal
+
+`apply_chat_template()` handles `image_url` content blocks: base64 data URIs are decoded to temp files; file paths and URLs are passed through. Images are wrapped in `<image>...</image>` tags for the model.
+
+### Tool Calling
+
+Tool calls are injected as a system prompt XML block (`inject_tool_prompt` in `server.py`). Model output with `<tool_call>` tags is parsed by `parse_model_output` and returned as structured tool call objects.
+
+## Platform Notes
+
+- Requires ARM hardware with Rockchip NPU (RK3588 or RK3576)
+- RKNPU driver version `v0.9.8` recommended (`cat /sys/kernel/debug/rknpu/version`)
+- The `.so` libraries in `lib/` must be loadable; for host installs run `sudo cp lib/*.so /usr/lib && sudo ldconfig`
+- When `--isDocker y`, model paths are prefixed with `/rkllm_server/models/`
+- For host installs, `fix_freq_rk3588.sh.d` is run at startup to stabilize CPU frequency
+- Python 3.12+ required

--- a/rkllm.py
+++ b/rkllm.py
@@ -221,8 +221,8 @@ class RKLLM(object):
         rkllm_param = RKLLMParam()
         rkllm_param.model_path = bytes(model_path, 'utf-8')
 
-        rkllm_param.max_context_len = 4096
-        rkllm_param.max_new_tokens = 4096
+        rkllm_param.max_context_len = 16384
+        rkllm_param.max_new_tokens = 8192
         rkllm_param.skip_special_token = True
         rkllm_param.n_keep = -1
         rkllm_param.top_k = 1
@@ -391,7 +391,9 @@ def get_RKLLM_output(rkllm_model, chat_formatted):
 
     finally:
         if model_thread.is_alive():
-            model_thread.join()
+            model_thread.join(timeout=10.0)
+            if model_thread.is_alive():
+                print("\n[Warning] Inference thread did not stop within timeout.")
         print("\n[Info] Inference thread finished.")
 
 

--- a/server.py
+++ b/server.py
@@ -182,105 +182,90 @@ def openai_embeddings(request: EmbeddingRequest):
 
 @app.post("/api/chat")
 def chat_endpoint(request: ChatRequest):
-    if not hw_lock.acquire(blocking=False):
-        raise HTTPException(status_code=503, detail="RKLLM Hardware is currently processing another request.")
-
-    try:
-        messages = request.messages
-        if request.tools:
-            messages = inject_tool_prompt(messages, request.tools)
-
-        messages_formatted = apply_chat_template(messages, thinking=request.think)
-        results = get_RKLLM_output(rkllm_model, messages_formatted)
-
-        if request.stream:
-            def stream_generator():
+    if request.stream:
+        def stream_generator():
+            if not hw_lock.acquire(blocking=True, timeout=30):
+                yield json.dumps({"error": "Server busy"}) + "\n"
+                return
+            try:
+                messages = request.messages
+                if request.tools:
+                    messages = inject_tool_prompt(messages, request.tools)
+                messages_formatted = apply_chat_template(messages, thinking=request.think)
+                results = get_RKLLM_output(rkllm_model, messages_formatted)
                 for r in results:
-                    chunk = {
+                    yield json.dumps({
                         "model": request.model if hasattr(request, 'model') else "rkllm",
                         "created_at": datetime.now(timezone.utc).isoformat() + "Z",
                         "message": {"role": "assistant", "content": r},
                         "done": False
-                    }
-                    yield json.dumps(chunk) + "\n"
-
+                    }) + "\n"
                 yield json.dumps({
                     "model": request.model if hasattr(request, 'model') else "rkllm",
                     "created_at": datetime.now(timezone.utc).isoformat() + "Z",
                     "message": {"role": "assistant", "content": ""},
                     "done": True
                 }) + "\n"
+            finally:
+                hw_lock.release()
+        return StreamingResponse(stream_generator(), media_type="application/x-ndjson")
 
-            return StreamingResponse(stream_generator(), media_type="application/x-ndjson")
-        else:
-            full_text = "".join(list(results))
-            clean_content, thinking_content, _ = parse_model_output(full_text, request.think is not False)
-
-            resp_msg = ResponseMessage(role="assistant", content=clean_content)
-            if thinking_content:
-                resp_msg.thinking = thinking_content
-
-            response_data = ChatResponse(
-                model=request.model if hasattr(request, 'model') else "rkllm",
-                created_at=datetime.now(timezone.utc).isoformat() + "Z",
-                message=resp_msg,
-                done=True
-            ).model_dump(exclude_none=True)
-
-            return JSONResponse(content=response_data)
-
+    if not hw_lock.acquire(blocking=True, timeout=30):
+        raise HTTPException(status_code=503, detail="RKLLM Hardware is currently processing another request.")
+    try:
+        messages = request.messages
+        if request.tools:
+            messages = inject_tool_prompt(messages, request.tools)
+        messages_formatted = apply_chat_template(messages, thinking=request.think)
+        results = get_RKLLM_output(rkllm_model, messages_formatted)
+        full_text = "".join(list(results))
+        clean_content, thinking_content, _ = parse_model_output(full_text, request.think is not False)
+        resp_msg = ResponseMessage(role="assistant", content=clean_content)
+        if thinking_content:
+            resp_msg.thinking = thinking_content
+        response_data = ChatResponse(
+            model=request.model if hasattr(request, 'model') else "rkllm",
+            created_at=datetime.now(timezone.utc).isoformat() + "Z",
+            message=resp_msg,
+            done=True
+        ).model_dump(exclude_none=True)
+        return JSONResponse(content=response_data)
     finally:
         hw_lock.release()
 
 
 @app.post("/v1/chat/completions")
 async def openai_chat_completions(request: ChatRequest):
-    if not hw_lock.acquire(blocking=False):
-        return JSONResponse(
-            status_code=503,
-            content={"error": {"message": "Server is busy", "type": "server_error", "code": "server_busy"}}
-        )
+    created_time = int(time.time())
+    model_name = os.path.basename(global_model) if global_model else "rkllm"
 
-    try:
-        messages = request.messages
-        messages_formatted = apply_chat_template(messages)
-        results = get_RKLLM_output(rkllm_model, messages_formatted)
-
-        created_time = int(time.time())
-        model_name = os.path.basename(global_model) if global_model else "rkllm"
-
-        if request.stream:
-            def stream_generator():
+    if request.stream:
+        def stream_generator():
+            if not hw_lock.acquire(blocking=True, timeout=30):
+                yield f"data: {json.dumps({'error': {'message': 'Server busy', 'type': 'server_error', 'code': 'server_busy'}})}\n\n"
+                return
+            try:
+                messages_formatted = apply_chat_template(request.messages)
+                results = get_RKLLM_output(rkllm_model, messages_formatted)
                 for r in results:
-                    chunk_data = {
-                        "id": f"chatcmpl-{created_time}",
-                        "object": "chat.completion.chunk",
-                        "created": created_time,
-                        "model": model_name,
-                        "choices": [
-                            {
-                                "index": 0,
-                                "delta": {"content": r},
-                                "finish_reason": None
-                            }
-                        ]
-                    }
-                    yield f"data: {json.dumps(chunk_data)}\n\n"
+                    yield f"data: {json.dumps({'id': f'chatcmpl-{created_time}', 'object': 'chat.completion.chunk', 'created': created_time, 'model': model_name, 'choices': [{'index': 0, 'delta': {'content': r}, 'finish_reason': None}]})}\n\n"
                 yield "data: [DONE]\n\n"
+            finally:
+                hw_lock.release()
+        return StreamingResponse(stream_generator(), media_type="text/event-stream")
 
-            return StreamingResponse(stream_generator(), media_type="text/event-stream")
-        else:
-            rkllm_output = "".join(list(results))
-            response_data = make_llm_response(rkllm_output)
-            response_data["created"] = created_time
-            response_data["model"] = model_name
-            return JSONResponse(content=response_data)
-
+    if not hw_lock.acquire(blocking=True, timeout=30):
+        return JSONResponse(status_code=503, content={"error": {"message": "Server is busy", "type": "server_error", "code": "server_busy"}})
+    try:
+        messages_formatted = apply_chat_template(request.messages)
+        results = get_RKLLM_output(rkllm_model, messages_formatted)
+        rkllm_output = "".join(list(results))
+        response_data = make_llm_response(rkllm_output)
+        response_data["created"] = created_time
+        response_data["model"] = model_name
+        return JSONResponse(content=response_data)
     except Exception as e:
-        return JSONResponse(
-            status_code=500,
-            content={"error": {"message": str(e), "type": "server_error", "code": "internal_error"}}
-        )
+        return JSONResponse(status_code=500, content={"error": {"message": str(e), "type": "server_error", "code": "internal_error"}})
     finally:
         hw_lock.release()
 
@@ -295,6 +280,123 @@ def list_openai_models():
             "object": "model",
             "owned_by": "rkllm_server",
             "created": int(time.time())
+        }]
+    })
+
+
+@app.post("/v1/messages")
+async def anthropic_messages(request: Request):
+    body = await request.json()
+    stream = body.get("stream", False)
+
+    # Convert Anthropic messages format to flat list
+    messages = []
+    system_prompt = body.get("system", "")
+    if system_prompt:
+        if isinstance(system_prompt, list):
+            system_prompt = " ".join(b.get("text", "") for b in system_prompt if isinstance(b, dict))
+        messages.append({"role": "system", "content": system_prompt})
+    for msg in body.get("messages", []):
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            content = " ".join(b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text")
+        messages.append({"role": msg["role"], "content": content})
+
+    model_name = body.get("model", os.path.basename(global_model) if global_model else "rkllm")
+    msg_id = f"msg_{int(time.time())}"
+
+    if stream:
+        def stream_generator():
+            if not hw_lock.acquire(blocking=True, timeout=30):
+                yield f"event: error\ndata: {json.dumps({'type':'error','error':{'type':'overloaded_error','message':'Server busy'}})}\n\n"
+                return
+            try:
+                messages_formatted = apply_chat_template(messages, thinking=False)
+                results = get_RKLLM_output(rkllm_model, messages_formatted)
+                yield f"event: message_start\ndata: {json.dumps({'type':'message_start','message':{'id':msg_id,'type':'message','role':'assistant','content':[],'model':model_name,'stop_reason':None,'usage':{'input_tokens':0,'output_tokens':1}}})}\n\n"
+                yield f"event: content_block_start\ndata: {json.dumps({'type':'content_block_start','index':0,'content_block':{'type':'text','text':''}})}\n\n"
+                yield "event: ping\ndata: {\"type\":\"ping\"}\n\n"
+                output_tokens = 0
+                try:
+                    for token in results:
+                        output_tokens += 1
+                        yield f"event: content_block_delta\ndata: {json.dumps({'type':'content_block_delta','index':0,'delta':{'type':'text_delta','text':token}})}\n\n"
+                except Exception:
+                    pass
+                finally:
+                    yield f"event: content_block_stop\ndata: {json.dumps({'type':'content_block_stop','index':0})}\n\n"
+                    yield f"event: message_delta\ndata: {json.dumps({'type':'message_delta','delta':{'stop_reason':'end_turn','stop_sequence':None},'usage':{'output_tokens':output_tokens}})}\n\n"
+                    yield "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+            finally:
+                hw_lock.release()
+        return StreamingResponse(stream_generator(), media_type="text/event-stream")
+
+    if not hw_lock.acquire(blocking=True, timeout=30):
+        return JSONResponse(status_code=529, content={"type": "error", "error": {"type": "overloaded_error", "message": "Server busy"}})
+    try:
+        messages_formatted = apply_chat_template(messages, thinking=False)
+        results = get_RKLLM_output(rkllm_model, messages_formatted)
+        full_text = "".join(list(results))
+        return JSONResponse(content={
+            "id": msg_id,
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": full_text}],
+            "model": model_name,
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 0, "output_tokens": len(full_text.split())}
+        })
+    finally:
+        hw_lock.release()
+
+
+@app.get("/api/version")
+def ollama_version():
+    return JSONResponse(content={"version": "0.9.0"})
+
+
+@app.get("/api/ps")
+def ollama_ps():
+    _model = os.path.basename(global_model) if global_model else "rkllm-model"
+    model_size = os.path.getsize(global_model) if global_model and os.path.exists(global_model) else 0
+    return JSONResponse(content={
+        "models": [{
+            "name": _model,
+            "model": _model,
+            "size": model_size,
+            "digest": "",
+            "expires_at": "0001-01-01T00:00:00Z",
+            "size_vram": model_size,
+            "details": {
+                "format": "rkllm",
+                "family": "rkllm",
+                "families": ["rkllm"],
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        }]
+    })
+
+
+@app.get("/api/tags")
+def ollama_list_models():
+    _model = os.path.basename(global_model) if global_model else "rkllm-model"
+    model_size = os.path.getsize(global_model) if global_model and os.path.exists(global_model) else 0
+    return JSONResponse(content={
+        "models": [{
+            "name": _model,
+            "model": _model,
+            "modified_at": datetime.now(timezone.utc).isoformat() + "Z",
+            "size": model_size,
+            "digest": "",
+            "details": {
+                "format": "rkllm",
+                "family": "rkllm",
+                "families": ["rkllm"],
+                "parameter_size": "",
+                "quantization_level": ""
+            }
         }]
     })
 


### PR DESCRIPTION
- rkllm.py: raise max_context_len from 4096 to 16384 and max_new_tokens from 4096 to 8192 to match actual model capacity
- rkllm.py: add timeout=10s to model_thread.join() so a failed abort() no longer blocks the finally block indefinitely, which was leaving hw_lock permanently acquired (server stuck in "busy")
- server.py: wrap Anthropic /v1/messages token loop in try/finally so content_block_stop + message_delta + message_stop are always sent, preventing "stream ended without a finish reason" SDK errors
- server.py: pass thinking=False to apply_chat_template for the Anthropic endpoint to suppress <think> blocks that the Anthropic SDK does not understand



This makes it work with qwen code / claude:

ANTHROPIC_AUTH_TOKEN=ollama ANTHROPIC_BASE_URL=http://localhost:8080 ANTHROPIC_API_KEY="" claude --model XXXX.rkllm